### PR TITLE
fix top css

### DIFF
--- a/src/features/top/components/titleSection/style.css.ts
+++ b/src/features/top/components/titleSection/style.css.ts
@@ -3,7 +3,6 @@ import { style } from "@vanilla-extract/css"
 export const styles = {
     titleBox: style({
         width: 250,
-        height: 200,
         fontSize: 26,
         textAlign: "center"
     })


### PR DESCRIPTION
topのコンポーネントのtitleBoxのcssのheightを削除してautoにしました。
closed #8