### PR TITLE
match introduction & modal style to Home

### DIFF
--- a/src/components/ui/card/style.css.ts
+++ b/src/components/ui/card/style.css.ts
@@ -7,8 +7,7 @@ const styles = {
         color: "#fff",
         padding: "1em",
         height: '100%',
-        transition: "0.4s",
-
+        transition: "box-shadow 0.4s",
         ":hover": {
             boxShadow: "0 0 15px 4px skyBlue",
         }

--- a/src/components/ui/header/langSelect/langSelect.view.tsx
+++ b/src/components/ui/header/langSelect/langSelect.view.tsx
@@ -14,9 +14,7 @@ const LangSelect = (props: props) => {
     const pathArr = usePathname().split("/")
     const params = useParams().id || ""
 
-    const getLinkPath = (path: string) => {
-        return `/${path}/${pathArr[2]}/${params}`
-    }
+    const getLinkPath = (path: string) => `/${path}/${pathArr[2]}/${params}`
 
     return (
         <div className={styles.selectLang}>

--- a/src/components/ui/popup/base/popup-base.tsx
+++ b/src/components/ui/popup/base/popup-base.tsx
@@ -9,13 +9,20 @@ interface props {
 export const PopupBase = (props: props) => {
     return (
         <>
-            <div className={styles.background} />
+            <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ property: 'opacity', duration: 0.5 }}
+                className={styles.background}
+            >
+            </motion.div>
             <div className={styles.mainContainer}>
                 <motion.div
-                    initial={{ x: 0, y: "100%" }}
-                    animate={{ x: 0, y: 0 }}
-                    exit={{ x: 0, y: "100%" }}
-                    transition={{ duration: 0.3 }}
+                    initial={{ x: 0, y: 70, opacity: 0 }}
+                    animate={{ x: 0, y: 0, opacity: 1 }}
+                    exit={{ x: 0, y: 70, opacity: 0 }}
+                    transition={{ duration: 0.5 }}
                     className={styles.container}
                 >
                     {props.children}

--- a/src/components/ui/popup/base/style.css.ts
+++ b/src/components/ui/popup/base/style.css.ts
@@ -2,32 +2,26 @@ import { style } from "@vanilla-extract/css"
 
 const styles = {
     background: style({
-        width: "100%",
-        height: "100%",
-        position: "absolute",
+        position: "fixed",
+        inset: 0,
         zIndex: 999,
-        bottom: 0,
-        left: 0,
-        opacity: 0.5,
-        backgroundColor: "black"
+        backgroundColor: "rgb(0 0 0/.5)",
+        backdropFilter: 'blur(4px)',
+        WebkitBackdropFilter: 'blur(4px)',
     }),
     mainContainer: style({
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        justifyContent: "center",
-        position: "absolute",
+        position: "fixed",
+        inset: 0,
         zIndex: 999,
-        bottom: 0,
-        left: 0,
-        alignItems: "center"
+        display: "grid",
+        placeItems: "center"
     }),
     container: style({
         width: 300,
         height: 500,
         padding: 30,
         position: "absolute",
-        zIndex: 999,
+        zIndex: 1000,
         backgroundColor: "white"
     })
 }

--- a/src/features/introduction/components/carrierCard/style.css.ts
+++ b/src/features/introduction/components/carrierCard/style.css.ts
@@ -2,63 +2,53 @@ import { style } from "@vanilla-extract/css"
 
 const styles = {
     intro: style({
-        width: "75%",
+        margin: "30px auto 0",
+        width: "min(90%, 900px)",
         borderRadius: 8,
-        margin: "30px auto",
-        boxShadow: "0 0 10px rgba(255,255,255,0.8)",
-        backgroundColor: "white",
-        padding: 25,
-        color: "black",
-        "@media": {
-            "screen and (max-width:430px)": {
-                paddingLeft: 0,
-                paddingRight: 0
-            },
-            "screen and (min-width:849px)": {
-                width: "50%"
-            }
-        }
+        backgroundColor: "#333",
+        paddingBlock: 25
     }),
     box: style({
-        display: "block",
-        marginBottom: 40,
+        display: "flex",
+        selectors: {
+            "&~&": {
+                marginTop: 25
+            }
+        },
         "@media": {
-            "screen and (min-width:849px)": {
-                display: "flex"
+            "(width < 850px)": {
+                flexDirection: "column",
+                alignItems: "center",
             }
         }
     }),
     titleBox: style({
+        width: "max(24%, 180px)",
         fontSize: 18,
-        paddingBottom: 15,
-        textAlign: "center",
-        borderBottom: "2px solid silver",
+        display: "grid",
+        paddingInline: 20,
+        placeItems: "center",
+        borderRight: "1px solid #555",
         "@media": {
-            "screen and (min-width:849px)": {
-                display: "flex",
-                paddingRight: 20,
-                justifyContent: "center",
-                alignItems: "center",
-                minWidth: 180,
-                borderBottom: "none"
+            "(width < 850px)": {
+                width: "fit-content",
+                paddingBottom: ".6em",
+                borderRight: "none",
+                borderBottom: "1px solid #555"
             }
         }
     }),
     introductionContents: style({
-        textAlign: "center",
+        flex: "1",
+        padding: "2em 20px",
         fontSize: 18,
-        padding: 4,
-        marginTop: 10,
+        textAlign: "left",
+        lineHeight: 1.7,
         "@media": {
-            "screen and (min-width:849px)": {
-                fontSize: 20,
-                textAlign: "left",
-                display: "flex",
-                alignItems: "center",
-                borderLeft: "4px solid black",
-                paddingLeft: 7,
-                minHeight: 210,
-                marginTop: 0
+            "(width < 850px)": {
+                fontSize: 16,
+                width: "fit-content",
+                padding: "20px max(3vw, 14px) 2em"
             }
         }
     })

--- a/src/features/introduction/components/introContents/introduction.tsx
+++ b/src/features/introduction/components/introContents/introduction.tsx
@@ -12,7 +12,7 @@ const IntroContents = (props: props) => {
         <section className={styles.section}>
             <div className={styles.intro}>
                 <div className={styles.titleBox}>
-                    <h2>{t.intro.introduction.title}</h2>
+                    <h2 className={styles.title}>{t.intro.introduction.title}</h2>
                 </div>
                 <div className={styles.introductionContents}>
                     {t.intro.introduction.contents}

--- a/src/features/introduction/components/introContents/style.css.ts
+++ b/src/features/introduction/components/introContents/style.css.ts
@@ -2,57 +2,52 @@ import { style } from "@vanilla-extract/css"
 
 const styles = {
     section: style({
-        marginTop: 20
+        margin: "20px auto 0",
+        width: "min(90%, 900px)"
     }),
     intro: style({
-        width: "75%",
+        width: "100%",
         borderRadius: 8,
-        margin: "auto",
-        boxShadow: "0 0 10px rgba(255,255,255,0.8)",
-        backgroundColor: "white",
-        padding: 25,
-        color: "black",
+        backgroundColor: "#333",
+        paddingBlock: 25,
+        display: "flex",
         "@media": {
-            "screen and (max-width:430px)": {
-                paddingLeft: 0,
-                paddingRight: 0
-            },
-            "screen and (min-width:849px)": {
-                width: "50%",
-                height: 250,
-                display: "flex"
+            "(width < 850px)": {
+                flexDirection: "column",
+                alignItems: "center",
+                paddingInline: "max(3vw, 14px)"
             }
         }
     }),
     titleBox: style({
-        fontSize: 18,
-        paddingBottom: 15,
-        borderBottom: "2px solid silver",
+        display: "grid",
+        paddingInline: 20,
+        width: "max(24%, 180px)",
+        placeItems: "center",
+        borderRight: "1px solid #555",
         "@media": {
-            "screen and (min-width:849px)": {
-                display: "flex",
-                paddingRight: 20,
-                justifyContent: "center",
-                alignItems: "center",
-                borderRight: "4px solid black",
-                height: 210,
-                borderBottom: "none"
+            "(width < 850px)": {
+                width: "fit-content",
+                paddingBottom: ".6em",
+                borderRight: "none",
+                borderBottom: "1px solid #555"
             }
         }
     }),
+    title: style({
+        fontSize: 18
+    }),
     introductionContents: style({
-        textAlign: "center",
+        flex: "1",
+        padding: "2em 20px",
         fontSize: 18,
-        padding: 4,
-        marginTop: 10,
+        display: "flex",
+        textAlign: "left",
+        lineHeight: 1.6,
         "@media": {
-            "screen and (min-width:855px)": {
-                fontSize: 20,
-                textAlign: "left",
-                display: "flex",
-                alignItems: "center",
-                paddingLeft: 7,
-                marginTop: 0
+            "(width < 850px)": {
+                fontSize: 16,
+                padding: "20px 0 0"
             }
         }
     })

--- a/src/features/introduction/components/introModal/style.css.ts
+++ b/src/features/introduction/components/introModal/style.css.ts
@@ -2,18 +2,17 @@ import { style } from "@vanilla-extract/css"
 
 const styles = {
     button: style({
-        width: 170,
-        height: 60,
-        border: "1px solid white",
-        borderRadius: 4,
-        backgroundColor: "white",
-        color: "black",
-        marginBottom: 5,
+        paddingBlock: '1em',
+        textAlign: 'center',
+        flex: "1",
+        borderRadius: 5,
+        border: "none",
+        backgroundColor: "#333",
+        transition: "box-shadow 0.4s",
         ":hover": {
-            boxShadow: "0 0 20px yellow",
-            transition: "0.6s"
+            boxShadow: "0 0 15px 4px skyBlue"
         },
-        fontSize: 24
+        fontSize: 20
     })
 }
 

--- a/src/features/introduction/components/introPopup/introPopup.tsx
+++ b/src/features/introduction/components/introPopup/introPopup.tsx
@@ -11,7 +11,6 @@ const IntroPopup = (props: props) => {
     return (
         <>
             <h2 className={styles.heading2}>{props.answer}</h2>
-            <div>
                 <div className={styles.description}>
                     <p className={styles.contents}>{props.description}</p>
                     {props.image && (
@@ -20,10 +19,10 @@ const IntroPopup = (props: props) => {
                             alt=""
                             width={200}
                             height={200}
+                            className={styles.img}
                         />
                     )}
                 </div>
-            </div>
         </>
     )
 }

--- a/src/features/introduction/components/introPopup/style.css.ts
+++ b/src/features/introduction/components/introPopup/style.css.ts
@@ -1,4 +1,5 @@
 import { style } from "@vanilla-extract/css"
+// import button from '../introModal/style.css'
 
 const styles = {
     heading2: style({
@@ -16,6 +17,12 @@ const styles = {
     contents: style({
         margin: 0,
         marginBottom: 10
+    }),
+    img: style({
+        width: '100%',
+        height: 'auto',
+        aspectRatio: '10/11',
+        objectFit: 'cover',
     })
 }
 

--- a/src/features/introduction/view/introduction.tsx
+++ b/src/features/introduction/view/introduction.tsx
@@ -16,26 +16,28 @@ export const Introduction = (props: props) => {
     const introModal = introData(props.lang)
 
     return (
-        <main className={styles.container}>
+        <>
             <Header title={t.intro.title} {...props} />
-            <h1 className={styles.title}>
-                {t.intro.introduction.sectionTitle}
-            </h1>
-            <IntroContents lang={props.lang} />
-            <h1 className={styles.title2}>{t.intro.carrier.title}</h1>
-            <CarrierCard lang={props.lang} />
-            <h1>{t.intro.introData.title}</h1>
-            <div className={styles.box}>
-                {introModal.map((item, index) => (
-                    <IntroModal key={index} title={item.title}>
-                        <IntroPopup
-                            answer={item.headerContents}
-                            description={item.bodyContents}
-                            {...item}
-                        />
-                    </IntroModal>
-                ))}
-            </div>
-        </main>
+            <main className={styles.container}>
+                <h1 className={styles.title}>
+                    {t.intro.introduction.sectionTitle}
+                </h1>
+                <IntroContents lang={props.lang} />
+                <h1 className={styles.title}>{t.intro.carrier.title}</h1>
+                <CarrierCard lang={props.lang} />
+                <h1 className={styles.title}>{t.intro.introData.title}</h1>
+                <div className={styles.box}>
+                    {introModal.map((item, index) => (
+                        <IntroModal key={index} title={item.title}>
+                            <IntroPopup
+                                answer={item.headerContents}
+                                description={item.bodyContents}
+                                {...item}
+                            />
+                        </IntroModal>
+                    ))}
+                </div>
+            </main>
+        </>
     )
 }

--- a/src/features/introduction/view/style.css.ts
+++ b/src/features/introduction/view/style.css.ts
@@ -2,24 +2,12 @@ import { style } from "@vanilla-extract/css"
 
 const styles = {
     container: style({
-        width: "100vw",
-        height: "100vh",
-        color: "white",
-        textAlign: "center",
-        overflow: "auto",
-        msOverflowStyle: "none",
-        scrollbarWidth: "none",
-        "::-webkit-scrollbar": {
-            display: "none"
-        }
+        paddingBlock: '60px max(5vw, 50px)',
     }),
     title: style({
-        marginTop: 100,
-        fontSize: 32
-    }),
-    title2: style({
         marginTop: 40,
-        fontSize: 32
+        fontSize: 32,
+        textAlign: 'center'
     }),
     contents1: style({
         margin: 0
@@ -29,16 +17,14 @@ const styles = {
         display: "flex"
     }),
     box: style({
-        width: "50%",
+        width: "min(90%, 900px)",
         margin: "20px auto",
         display: "flex",
-        justifyContent: "space-around",
+        gap: 'max(1em, 8px)',
         "@media": {
-            "screen and (max-width:470px)": {
-                width: 170,
-                display: "block",
-                gap: 0,
-                textAlign: "center"
+            "screen and (max-width:850px)": {
+                width: 'min(90%, 360px)',
+                flexDirection: "column",
             }
         }
     })

--- a/src/features/skills/view/skills-page.tsx
+++ b/src/features/skills/view/skills-page.tsx
@@ -15,10 +15,10 @@ export const SkillsPage = (props: props) => {
     return (
         <>
             <Header title="" {...props} />
-            <div className={styles.container}>
+            <main className={styles.container}>
                 <CardView pageTitle={t.skills.title} contents={skills} />
                 <div className={styles.space} />
-            </div>
+            </main>
         </>
     )
 }


### PR DESCRIPTION
introduction画面をhome画面のデザインに合わて諸々調整してみました。
#fffと#000の組み合わせはコントラストが最大のため、これを多用するとwebでは目が疲れて離脱率が上がると言われますので、カードのbgを#333にしてみました。グレーが#fffと#000の間に介在することで落ち着いた印象になったと思います。もしカードのbgは#fffがいい！とかなら他の方法を考えますので一度ご検討いただけませんでしょうか。よろしくお願いします！
レスポンシブはブレイクポイントを統一してシームレスに切り替わるようにしてみました。ご確認お願いします。
また、モーダルのアニメーションをほんの少しだけふわっと、じわっとさせてほんのり色気のある感じ、情緒感を足してみました。これも好みですのでご検討ください！おなしゃす！！！！
closed #19