### PR TITLE
ビルドエラー解消

### DIFF
--- a/src/services/markdown/view/a/model/get-url-contents/get-url-contents.ts
+++ b/src/services/markdown/view/a/model/get-url-contents/get-url-contents.ts
@@ -8,7 +8,12 @@ export const getUrlContents = async (url: string) => {
         throw new Error("response is failed")
     }
     const html = await res.text()
-    const DOM = new JSDOM(html)
+
+    const replaceHTML = html
+        .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, "")
+        .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "")
+
+    const DOM = new JSDOM(replaceHTML)
 
     const twitterPost = url.match(/https:\/\/x\.com\/([\w]+)\/status\/([\d]+)/)
 


### PR DESCRIPTION
closed #58

# 変更

スクレイピングをしたHTMLをテキストに変換した後、`style`と`script`を削除する

# 原因

`jsdom`の部分でcssの文法がおかしかったり長かったりするとcssomの部分でerrorが起こってしまうらしい
 
